### PR TITLE
Fix: Add dev:mock script to root package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "verify": "forge verify-contract",
     "keeper:dev": "cd keeper && npm run dev",
     "subgraph:build": "cd subgraph && graph build",
-    "app:dev": "cd app && npm run dev"
+    "app:dev": "cd app && npm run dev",
+    "dev:mock": "cd frontend && npm run dev:mock"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- Fixed `npm run dev:mock` not working from project root
- Added convenience script to root package.json that navigates to frontend directory
- Resolved frontend dependency installation issues

## Problem
The `dev:mock` script existed only in `frontend/package.json`, requiring users to manually navigate to the frontend directory to run it. Additionally, dependencies weren't installed.

## Solution
1. Installed frontend dependencies using `npm install --legacy-peer-deps` to handle React 19 peer dependency conflicts
2. Added a convenience script to the root `package.json` that automatically navigates to the frontend directory and runs the mock development server

## Test plan
- [ ] Run `npm run dev:mock` from project root
- [ ] Verify the development server starts successfully
- [ ] Confirm mock data is available when `NEXT_PUBLIC_ENABLE_MOCKS=true` is set

🤖 Generated with [Claude Code](https://claude.ai/code)